### PR TITLE
Update setup.py; add tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ MANIFEST
 *.sw?
 *.pyc
 __pycache__/
+.tox/
+mozilla_cloud_services_logger.egg-info/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ sudo: false
 python:
     - "2.7"
     - "3.5"
+    - "3.6"
 install: pip install jsonschema testfixtures
 script: python tests.py

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,12 @@
-from distutils.core import setup
+from setuptools import setup
+
+
 setup(
   name = 'mozilla-cloud-services-logger',
   packages = ['mozilla_cloud_services_logger', 'mozilla_cloud_services_logger.django'],
   version = '1.0.1',
   description = 'Tools for producing a common application logging format defined by Mozilla Cloud Services',
+  license = "MPLv2",
   author = 'Les Orchard',
   author_email = 'lorchard@mozilla.com',
   url = 'https://github.com/mozilla/mozilla-cloud-services-logger',
@@ -15,6 +18,11 @@ setup(
      'Intended Audience :: Developers',
      'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
      'Operating System :: OS Independent',
+     'Programming Language :: Python :: 2',
+     'Programming Language :: Python :: 2.7',
+     'Programming Language :: Python :: 3',
+     'Programming Language :: Python :: 3.5',
+     'Programming Language :: Python :: 3.6',
      'Topic :: Software Development :: Libraries :: Python Modules',     
   ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py27,py35,py36
+
+[testenv]
+commands =
+    pip install jsonschema testfixtures
+    python tests.py


### PR DESCRIPTION
This:

* adds a `tox.ini` file making it easier to test multiple Python versions locally
* adds the Python versions to the `setup.py` Trove data which is helpful for PyPI Python version tracking
* adds Python 3.6 to the list of environments to test in because a bunch of us are using Python 3.6 and we should test that environment