### PR TITLE
Use 'msg' key instead of 'message' (fixes #2)

### DIFF
--- a/mozilla_cloud_services_logger/formatters.py
+++ b/mozilla_cloud_services_logger/formatters.py
@@ -73,7 +73,7 @@ class JsonLogFormatter(logging.Formatter):
         message = record.getMessage()
         if message:
             if not message.startswith("{") and not message.endswith("}"):
-                fields["message"] = message
+                fields["msg"] = message
 
         # If there is an error, format it for nice output.
         if record.exc_info is not None:

--- a/tests.py
+++ b/tests.py
@@ -47,7 +47,7 @@ class TestJsonLogFormatter(unittest.TestCase):
         for key, value in expected_meta.items():
             self.assertEqual(value, details[key])
 
-        self.assertEqual(details['Fields']['message'], message_text)
+        self.assertEqual(details['Fields']['msg'], message_text)
 
     def test_custom_paramters(self):
         """Ensure log formatter can handle custom parameters"""
@@ -59,7 +59,7 @@ class TestJsonLogFormatter(unittest.TestCase):
         self.assertEqual(details["Severity"], 4)
 
         fields = details['Fields']
-        self.assertEqual(fields["message"], "custom test one")
+        self.assertEqual(fields["msg"], "custom test one")
         self.assertEqual(fields["more"], "stuff")
 
     def test_logging_error_tracebacks(self):
@@ -78,7 +78,7 @@ class TestJsonLogFormatter(unittest.TestCase):
 
         fields = details['Fields']
         expected_fields = {
-            'message': 'there was an error',
+            'msg': 'there was an error',
             'error': "ValueError('\\n',)"
         }
         for key, value in expected_fields.items():


### PR DESCRIPTION
Fixes #2

As stated in https://wiki.mozilla.org/Firefox/Services/Logging

I'm aware this is a breaking change, let me know if you'd rather keep some sort of backward compatibility
